### PR TITLE
Moving Zendesk init to javascripts block

### DIFF
--- a/app/views/mas/feedback/_zendesk.html.erb
+++ b/app/views/mas/feedback/_zendesk.html.erb
@@ -4,6 +4,7 @@
   <%= javascript_include_tag 'mas/feedback/zenbox' %>
 <% end %>
 
+<% content_for :javascripts do %>
 <script type="text/javascript">
   if (typeof(Zenbox) !== "undefined") {
     Zenbox.init({
@@ -16,3 +17,4 @@
     });
   }
 </script>
+<% end %>


### PR DESCRIPTION
This fixes Zendesk buttons on IE8
